### PR TITLE
fix: restore tennis live debug flow (v0.96.14)

### DIFF
--- a/api/gs/tennis-live.js
+++ b/api/gs/tennis-live.js
@@ -4,11 +4,6 @@ const { fetchLiveTennis } = require('../_lib/goalServeLiveAPI.js');
 module.exports = async (req, res) => {
   try {
     const matches = await fetchLiveTennis();
-
-    if (!Array.isArray(matches) || matches.length === 0) {
-      console.warn('[API] ⚠ No matches returned from fetchLiveTennis');
-    }
-
     res.status(200).json({ matches });
   } catch (error) {
     console.error('[API] ❌ Handler error in /api/gs/tennis-live:', error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react-dom": "^18.2.0",
         "react-icons": "^4.12.0",
         "react-scripts": "5.0.1",
+        "undici": "^7.15.0",
         "xml2js": "^0.6.2"
       }
     },
@@ -16659,6 +16660,15 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
       "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.15.0.tgz",
+      "integrity": "sha512-7oZJCPvvMvTd0OlqWsIxTuItTpJBpU1tcbVl24FMn3xt3+VSunwUasmfPJRE57oNO1KsZ4PgA1xTdAX4hq8NyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.10.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "react-dom": "^18.2.0",
     "react-icons": "^4.12.0",
     "react-scripts": "5.0.1",
+    "undici": "^7.15.0",
     "xml2js": "^0.6.2"
   },
   "scripts": {

--- a/src/utils/fetchTennisLive.js
+++ b/src/utils/fetchTennisLive.js
@@ -1,22 +1,21 @@
-const API_URL = 'https://livebetiq3.vercel.app/api/gs/tennis-live'; // Vercel-only endpoint
-
+// File: src/utils/fetchTennisLive.js v0.96.14-debug
 export default async function fetchTennisLive() {
   try {
-    const res = await fetch(API_URL);
-    if (!res.ok) {
-      console.error(`Fetch failed with status ${res.status}`);
-      return { matches: [] };
-    }
+    const res = await fetch('https://livebetiq3.vercel.app/api/gs/tennis-live');
+    const data = await res.json();
 
-    const json = await res.json();
-    if (!json || !Array.isArray(json.matches)) {
-      console.warn('Invalid API response format:', json);
-      return { matches: [] };
-    }
+    console.log('🎯 [fetchTennisLive] Response status:', res.status);
+    console.log('🎯 [fetchTennisLive] Matches:', data.matches?.length);
+    console.table((data.matches || []).map(m => ({
+      id: m.id || m['@id'],
+      status: m.status || m['@status'],
+      player1: m?.player?.[0]?.name || m?.players?.[0]?.name,
+      player2: m?.player?.[1]?.name || m?.players?.[1]?.name,
+    })));
 
-    return { matches: json.matches };
-  } catch (err) {
-    console.error('Fetch error:', err.message || err);
-    return { matches: [] };
+    return Array.isArray(data.matches) ? data.matches : [];
+  } catch (e) {
+    console.warn('[fetchTennisLive] API Error:', e.message);
+    return [];
   }
 }


### PR DESCRIPTION
This PR restores the previous working version of the LiveBet IQ Tennis AI system.

🔧 Fixes:
- Removes broken nested repo `livebetiq-api`
- Reverts GoalServe API logic to v0.96.14 (working debug state)
- Keeps AI modules stable (EV, Confidence, Kelly, Momentum)

🎯 Goal:
To recover the debug state where matches were visible and AI predictions were rendered properly.

🔄 Target version: `v0.96.14-debug`

Next step: validate if matches appear in `/LiveTennis.js` via polling from `fetchTennisLive()`.